### PR TITLE
Format output

### DIFF
--- a/lib/rspec/rest/config.rb
+++ b/lib/rspec/rest/config.rb
@@ -3,13 +3,23 @@
 module RSpec
   module Rest
     class Config
-      attr_accessor :app, :base_path, :base_headers, :default_format
+      DEFAULT_REDACT_HEADERS = %w[
+        Authorization
+        Proxy-Authorization
+        Cookie
+        Set-Cookie
+        X-Api-Key
+        X-Auth-Token
+      ].freeze
 
-      def initialize(app: nil, base_path: nil, base_headers: nil, default_format: nil)
+      attr_accessor :app, :base_path, :base_headers, :default_format, :redact_headers
+
+      def initialize(app: nil, base_path: nil, base_headers: nil, default_format: nil, redact_headers: nil)
         @app = app
         @base_path = base_path || ""
         @base_headers = (base_headers || {}).dup
         @default_format = default_format
+        @redact_headers = (redact_headers || DEFAULT_REDACT_HEADERS).dup
       end
     end
   end

--- a/lib/rspec/rest/dsl.rb
+++ b/lib/rspec/rest/dsl.rb
@@ -17,7 +17,8 @@ module RSpec
             app: config.app,
             base_path: config.base_path,
             base_headers: config.base_headers,
-            default_format: config.default_format
+            default_format: config.default_format,
+            redact_headers: config.redact_headers
           )
         end
 
@@ -35,6 +36,10 @@ module RSpec
 
         def default_format(value)
           @config.default_format = value
+        end
+
+        def redact_headers(value)
+          @config.redact_headers = value.dup
         end
 
         def to_config
@@ -76,7 +81,8 @@ module RSpec
             app: parent.app,
             base_path: parent.base_path,
             base_headers: parent.base_headers,
-            default_format: parent.default_format
+            default_format: parent.default_format,
+            redact_headers: parent.redact_headers
           )
         end
 

--- a/lib/rspec/rest/expectations.rb
+++ b/lib/rspec/rest/expectations.rb
@@ -93,7 +93,8 @@ module RSpec
       def request_dump
         Formatters::RequestDump.new(
           last_request: safe_last_request,
-          response: safe_rest_response
+          response: safe_rest_response,
+          redacted_headers: redacted_headers_for_dump
         ).format
       end
 
@@ -106,6 +107,12 @@ module RSpec
       def safe_rest_response
         rest_response
       rescue MissingRequestContextError, StandardError
+        nil
+      end
+
+      def redacted_headers_for_dump
+        self.class.rest_config.redact_headers
+      rescue StandardError
         nil
       end
     end

--- a/spec/rspec/rest/failure_output_spec.rb
+++ b/spec/rspec/rest/failure_output_spec.rb
@@ -10,7 +10,10 @@ RSpec.describe RSpec::Rest do
   api do
     app RackApp.new
     base_path "/v1"
-    base_headers "Accept" => "application/json"
+    base_headers(
+      "Accept" => "application/json",
+      "Authorization" => "Bearer super-secret-token"
+    )
     default_format :json
   end
 
@@ -21,6 +24,8 @@ RSpec.describe RSpec::Rest do
       end.to raise_error(RSpec::Expectations::ExpectationNotMetError) { |error|
         expect(error.message).to include("Request:")
         expect(error.message).to include("GET /v1/users")
+        expect(error.message).to include("Authorization: [REDACTED]")
+        expect(error.message).not_to include("super-secret-token")
         expect(error.message).to include("Response:")
         expect(error.message).to include("Status: 200")
         expect(error.message).to include("\"id\": 1")

--- a/spec/rspec/rest/formatters/request_dump_spec.rb
+++ b/spec/rspec/rest/formatters/request_dump_spec.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe RSpec::Rest::Formatters::RequestDump do
+  let(:response_struct) { Struct.new(:status, :headers, :body) }
+
+  def build_dump(last_request:, response_headers:, response_body:, redacted_headers: nil)
+    described_class.new(
+      last_request: last_request,
+      response: response_struct.new(200, response_headers, response_body),
+      redacted_headers: redacted_headers
+    ).format
+  end
+
+  def expect_default_redaction(dump)
+    expect(dump).to include("Authorization: [REDACTED]")
+    expect(dump).to include("Set-Cookie: [REDACTED]")
+    expect(dump).to include("Accept: application/json")
+    expect(dump).not_to include("Bearer secret")
+    expect(dump).not_to include("top-secret")
+  end
+
+  def expect_custom_redaction(dump)
+    expect(dump).to include("X-Custom-Secret: [REDACTED]")
+    expect(dump).to include("Authorization: Bearer visible")
+    expect(dump).not_to include("X-Custom-Secret: shh")
+  end
+
+  it "redacts sensitive headers by default" do
+    dump = build_dump(
+      last_request: {
+        method: "GET",
+        path: "/v1/users",
+        headers: {
+          "Authorization" => "Bearer secret",
+          "Accept" => "application/json"
+        },
+        body: ""
+      },
+      response_headers: { "Set-Cookie" => "session=top-secret", "Content-Type" => "application/json" },
+      response_body: '{"ok":true}'
+    )
+
+    expect_default_redaction(dump)
+  end
+
+  it "supports configurable header redaction list" do
+    dump = build_dump(
+      last_request: {
+        method: "GET",
+        path: "/v1/users",
+        headers: {
+          "X-Custom-Secret" => "shh",
+          "Authorization" => "Bearer visible"
+        },
+        body: ""
+      },
+      response_headers: {},
+      response_body: "",
+      redacted_headers: ["X-Custom-Secret"]
+    )
+
+    expect_custom_redaction(dump)
+  end
+end


### PR DESCRIPTION
# Pull Request

## Summary
This PR implements Milestone 5 by adding high-signal failure output for DSL assertions. It introduces a `RequestDump` formatter that captures full request/response context (method/path, headers, body, status) with JSON pretty-printing where possible, and wires it into `expect_status`, `expect_header`, and `expect_json` so assertion failures automatically include actionable debugging context.

## User Story
As a Ruby/Rails engineer writing API specs with `rspec-rest`, I want failed assertions to include a complete request/response dump so that I can diagnose failures quickly without adding temporary debug output.

## Acceptance Criteria
- [ ] A request/response dump formatter exists and includes:
  - [ ] request method + path
  - [ ] request headers
  - [ ] request body
  - [ ] response status
  - [ ] response headers
  - [ ] response body
- [ ] JSON request/response bodies are pretty-printed when valid JSON.
- [ ] DSL assertion failures in:
  - [ ] `expect_status`
  - [ ] `expect_header`
  - [ ] `expect_json`
  include the formatted dump.
- [ ] Failure output is local to the gem’s DSL behavior (no global RSpec monkeypatching).
- [ ] Failure-output specs verify that enriched messages include both request and response context.
- [ ] `bundle exec rspec` passes.
- [ ] `bundle exec rubocop` passes.

## Related Issue
Closes #6 

## Implementation Notes
List key design decisions, tradeoffs, and any intentional deviations from plan.

## Testing
- [ ] `bundle exec rspec`
- [ ] Added/updated specs for changed behavior
- [ ] Manual verification steps (if applicable)

### Test Evidence
Paste relevant output or describe results.

## Checklist
- [ ] Backward compatibility considered
- [ ] Errors/failure messages are actionable
- [ ] README/docs updated (if behavior changed)
- [ ] CHANGELOG updated (if release-impacting)

## GitHub Copilot Review Instructions
When reviewing this PR, focus on the following:

1. Adhere to SOLID principles:
   - Single responsibility for classes/modules.
   - Open/closed design for extensibility.
   - Liskov substitution and interface consistency.
   - Interface segregation (small, focused APIs).
   - Dependency inversion where practical.
2. Follow Ruby gem best practices:
   - Clear public API boundaries and stable namespace (`RSpec::Rest`).
   - Minimal dependencies and explicit version constraints.
   - Meaningful error types/messages and defensive input handling.
   - Avoid global side effects/monkeypatching.
3. Follow RSpec-integrated gem best practices:
   - Deterministic specs (no order leakage, no shared mutable state).
   - Per-example isolation for config/session/captures.
   - Matchers and failures should produce high-signal diagnostics.
   - Keep DSL behavior explicit, predictable, and well-covered by specs.
4. Project-specific expectations:
   - Preserve Rack::Test in-process execution for speed.
   - Keep JSON handling robust (invalid JSON, missing keys/selectors).
   - Failure output must include enough request/response context to debug quickly.
   - Prefer readable, maintainable DSL implementation over clever metaprogramming.

If you find issues, provide concrete suggestions and point to exact files/lines.
