### PR TITLE
Add bearer token and expect_json_at helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,12 +115,13 @@ RSpec.describe "Posts API" do
 
   resource "/posts" do
     get "/" do
-      header "Authorization", "Bearer #{auth_token}"
+      bearer auth_token
       query page: 1, per_page: 10
 
       expect_status 200
       expect_json array_of(hash_including("id" => integer, "author" => hash_including("id" => integer)))
-      expect_json { |payload| expect(payload.first["id"]).to eq(posts.first.id) }
+      expect_json_at "$[0].id", posts.first.id
+      expect_json_at "$[0].author.id", posts.first.author.id
     end
   end
 end
@@ -180,6 +181,8 @@ Inside verb blocks:
 
 - `header(key, value)`
 - `headers(hash)`
+- `bearer(token)`
+- `unauthenticated!`
 - `query(hash)`
 - `json(hash_or_string)`
 - `path_params(hash)`
@@ -189,6 +192,7 @@ Example:
 ```ruby
 post "/" do
   headers "X-Trace-Id" => "abc-123"
+  bearer "token-123"
   query include_details: "true"
   json "email" => "dev@example.com", "name" => "Dev"
   expect_status 201
@@ -202,6 +206,7 @@ Available expectation helpers:
 - `expect_status(code)`
 - `expect_header(key, value_or_regex)`
 - `expect_json(expected = nil, &block)`
+- `expect_json_at(selector, expected = nil, &block)`
 
 `expect_json` supports:
 
@@ -211,6 +216,15 @@ Available expectation helpers:
   - `expect_json("id" => 1, "email" => "jane@example.com", "name" => "Jane")`
 - block mode:
   - `expect_json { |payload| expect(payload["id"]).to integer }`
+
+`expect_json_at` supports the same matcher/equality/block modes against a selected path:
+
+- matcher mode:
+  - `expect_json_at "$.user.id", integer`
+- equality mode:
+  - `expect_json_at "$.user.email", "jane@example.com"`
+- block mode:
+  - `expect_json_at "$.items[0]" { |item| expect(item["id"]).to integer }`
 
 JSON type helpers:
 

--- a/docs/plan_0_2.md
+++ b/docs/plan_0_2.md
@@ -1,0 +1,229 @@
+# rspec-rest — Plan 0.2
+
+## 1) Goal
+Ship `0.2.0` as a developer-experience release focused on reducing repetitive request-spec boilerplate in real-world API suites (especially Rails + Grape style APIs).
+
+Primary outcomes:
+- less auth/header/query setup repetition
+- cleaner nested JSON assertions
+- first-class API error assertions
+- better support for multipart/file upload flows
+- reusable request presets at resource scope
+- simpler pagination assertions
+- optional lightweight response contracts
+
+---
+
+## 2) Scope
+
+### In scope for `0.2.0`
+- Auth helpers
+- JSON path assertions
+- Error payload helpers
+- Multipart/file upload builder
+- Request presets/shared modifiers
+- Pagination helpers
+- Lightweight response contract helper
+
+### Out of scope for `0.2.0`
+- OpenAPI schema generation/validation
+- Full JSONPath implementation
+- Response snapshot framework
+- Alternate non-Rack test runner
+
+---
+
+## 3) Proposed DSL Additions
+
+### 3.1 Auth helpers
+- `bearer(token)`
+- `unauthenticated!` (removes `Authorization` from current request headers)
+
+Example:
+```ruby
+get "/" do
+  bearer access_token
+  expect_status 200
+end
+```
+
+### 3.2 JSON path assertions
+- `expect_json_at(selector, expected = nil, &block)`
+  - selector supports existing minimal syntax (`$.a.b`, `$.items[0].id`)
+  - matcher/value/block behavior mirrors `expect_json`
+
+Example:
+```ruby
+expect_json_at "$.comments[0].author.id", eq(user.id)
+```
+
+### 3.3 Error payload helpers
+- `expect_error(status:, message: nil, includes: nil, field: nil, key: "error")`
+  - asserts status first
+  - checks error key content (string or array)
+  - `includes:` supports partial matching
+  - `field:` adds convenience for validation-style errors
+
+Examples:
+```ruby
+expect_error status: 422, message: "Unable to like post"
+expect_error status: 400, includes: "font_size"
+```
+
+### 3.4 Multipart/file upload
+- `multipart!`
+- `file(param_key, file_or_path, content_type: nil, filename: nil)`
+
+Example:
+```ruby
+post "/" do
+  multipart!
+  file :image, Rails.root.join("spec/fixtures/files/test_image.jpg"), content_type: "image/jpeg"
+  expect_status 201
+end
+```
+
+### 3.5 Request presets/shared modifiers
+- `with_headers(hash)`
+- `with_query(hash)`
+- `with_auth(token)` (resource/group-level default bearer)
+- presets are inherited by nested `resource` blocks and merged with per-request values
+
+Example:
+```ruby
+resource "/posts" do
+  with_auth token
+  with_query per_page: 20
+
+  get "/" do
+    query page: 2
+    expect_status 200
+  end
+end
+```
+
+### 3.6 Pagination helpers
+- `expect_page_size(size)`
+- `expect_max_page_size(max)`
+- `expect_ids_in_order(ids, selector: "$[*].id")`
+
+Examples:
+```ruby
+expect_page_size 10
+expect_max_page_size 20
+expect_ids_in_order [post3.id, post2.id, post1.id]
+```
+
+### 3.7 Lightweight response contracts
+- `contract(name, &definition)` to define reusable JSON matcher blocks
+- `expect_json_contract(name)`
+
+Example:
+```ruby
+contract :post_summary do
+  hash_including(
+    "id" => integer,
+    "title" => string,
+    "author" => hash_including("id" => integer)
+  )
+end
+
+expect_json array_of(expect_json_contract(:post_summary))
+```
+
+---
+
+## 4) Milestones
+
+### Milestone 1: Auth + JSON path assertions
+Deliver:
+- `bearer`, `unauthenticated!`
+- `expect_json_at`
+
+Acceptance:
+- Can replace manual `Authorization` header setup in specs
+- Nested assertion example passes/fails with clear failure output + curl
+
+### Milestone 2: Error helpers + pagination helpers
+Deliver:
+- `expect_error`
+- `expect_page_size`, `expect_max_page_size`, `expect_ids_in_order`
+
+Acceptance:
+- Validation/permission error examples become one-liners
+- Pagination assertions no longer rely on repeated `json.size`/manual id extraction
+
+### Milestone 3: Multipart/file upload
+Deliver:
+- `multipart!`
+- `file(...)`
+
+Acceptance:
+- Image/video upload request specs can be expressed without raw Rack::Test multipart plumbing
+- Failing multipart expectations still include full request dump/curl
+
+### Milestone 4: Request presets/shared modifiers
+Deliver:
+- `with_headers`, `with_query`, `with_auth`
+- merge/inheritance behavior for nested resources
+
+Acceptance:
+- Shared auth + common pagination defaults are declared once and reused
+- Request-local values override defaults predictably
+
+### Milestone 5: Lightweight contracts
+Deliver:
+- `contract`
+- `expect_json_contract`
+
+Acceptance:
+- Repeated response-shape checks can be defined once and reused
+- Contract failures identify contract name and failing matcher path
+
+---
+
+## 5) Technical Notes
+
+- Keep features additive and backward compatible with `0.1.x` DSL.
+- Reuse existing `JsonSelector` for `expect_json_at` to avoid duplicating selector logic.
+- Ensure new helpers all route through current failure wrapper so request dump/curl remains consistent.
+- Avoid introducing global RSpec monkeypatching.
+- Prefer explicit config and per-example isolation semantics already used by the gem.
+
+---
+
+## 6) Testing Strategy
+
+Add/extend specs under:
+- `spec/rspec/rest/dsl_spec.rb`
+- `spec/rspec/rest/expectations_spec.rb` (new file if needed)
+- `spec/rspec/rest/acceptance_spec.rb`
+- `spec/rspec/rest/failure_output_spec.rb`
+
+Minimum test matrix:
+- happy path + failure path for each new helper
+- interaction tests for presets merge/override behavior
+- multipart request and content-type correctness
+- error helper on both string and array payload formats
+- pagination helper with array payload and invalid payload types
+
+---
+
+## 7) Documentation Deliverables
+
+- Update README with:
+  - new helper sections
+  - one end-to-end "before vs after" covering auth + pagination + errors
+  - multipart example
+  - contract example
+- Add changelog entry for `0.2.0`.
+
+---
+
+## 8) Release Criteria (`0.2.0`)
+
+- All new helpers implemented and documented
+- Full spec suite green
+- No regressions in existing DSL behavior
+- Changelog updated
+- Version bumped to `0.2.0`

--- a/lib/rspec/rest/dsl.rb
+++ b/lib/rspec/rest/dsl.rb
@@ -149,6 +149,14 @@ module RSpec
           rest_request_state[:path_params].merge!(value.transform_keys(&:to_s))
         end
 
+        def bearer(token)
+          header("Authorization", "Bearer #{token}")
+        end
+
+        def unauthenticated!
+          header("Authorization", nil)
+        end
+
         private
 
         def start_rest_request(method:, path:, resource_path:)

--- a/lib/rspec/rest/expectations.rb
+++ b/lib/rspec/rest/expectations.rb
@@ -2,10 +2,14 @@
 
 require_relative "formatters/request_dump"
 require_relative "formatters/request_recorder"
+require_relative "json_selector"
+require_relative "json_type_helpers"
 
 module RSpec
   module Rest
     module Expectations
+      include JsonTypeHelpers
+
       def expect_status(code)
         with_request_dump_on_failure do
           expect(rest_response.status).to eq(code)
@@ -49,24 +53,25 @@ module RSpec
         end
       end
 
-      def integer
-        be_a(Integer)
-      end
+      def expect_json_at(selector, expected = nil, &block)
+        with_request_dump_on_failure do
+          selected = JsonSelector.extract(rest_response.json, selector)
 
-      def string
-        be_a(String)
-      end
+          if block
+            instance_exec(selected, &block)
+            next selected
+          end
 
-      def boolean
-        satisfy("be boolean") { |value| [true, false].include?(value) }
-      end
+          next selected if expected.nil?
 
-      def array_of(matcher)
-        all(matcher)
-      end
+          if expected.respond_to?(:matches?)
+            expect(selected).to expected
+          else
+            expect(selected).to eq(expected)
+          end
 
-      def hash_including(*)
-        a_hash_including(*)
+          selected
+        end
       end
 
       private

--- a/lib/rspec/rest/json_type_helpers.rb
+++ b/lib/rspec/rest/json_type_helpers.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+module RSpec
+  module Rest
+    module JsonTypeHelpers
+      def integer
+        be_a(Integer)
+      end
+
+      def string
+        be_a(String)
+      end
+
+      def boolean
+        satisfy("be boolean") { |value| [true, false].include?(value) }
+      end
+
+      def array_of(matcher)
+        all(matcher)
+      end
+
+      def hash_including(*)
+        a_hash_including(*)
+      end
+    end
+  end
+end

--- a/lib/rspec/rest/session.rb
+++ b/lib/rspec/rest/session.rb
@@ -76,12 +76,25 @@ module RSpec
           headers["Accept"] ||= "application/json"
         end
 
-        headers.merge!(request_headers || {})
+        merge_request_headers!(headers, request_headers || {})
         if include_json_content_type
           headers["Content-Type"] ||= "application/json"
         end
 
         headers
+      end
+
+      def merge_request_headers!(headers, request_headers)
+        request_headers.each do |key, value|
+          if value.nil?
+            headers.delete_if { |header_key, _| header_key.to_s.casecmp(key.to_s).zero? }
+            next
+          end
+
+          existing_key = headers.keys.find { |header_key| header_key.to_s.casecmp(key.to_s).zero? }
+          headers.delete(existing_key) if existing_key && existing_key != key
+          headers[key] = value
+        end
       end
 
       def build_payload(json:, params:)

--- a/spec/rspec/rest/dsl_spec.rb
+++ b/spec/rspec/rest/dsl_spec.rb
@@ -26,7 +26,10 @@ RSpec.describe RSpec::Rest do
   api do
     app RackApp.new
     base_path "/v1"
-    base_headers "Accept" => "application/json"
+    base_headers(
+      "Accept" => "application/json",
+      "Authorization" => "Bearer base-token"
+    )
     default_format :json
   end
 
@@ -38,6 +41,7 @@ RSpec.describe RSpec::Rest do
       expect_json array_of(hash_including("id" => integer, "email" => string))
       expect(last_request[:path]).to eq("/v1/users")
       expect(last_request[:headers]["Accept"]).to eq("application/json")
+      expect(last_request[:headers]["Authorization"]).to eq("Bearer base-token")
     end
 
     get "/{id}" do
@@ -61,6 +65,15 @@ RSpec.describe RSpec::Rest do
       expect_json do |payload|
         expect(payload["id"]).to integer
         expect(payload["email"]).to string
+      end
+    end
+
+    get "/{id}" do
+      path_params id: 2
+      expect_json_at("$.email", "alex@example.com")
+      expect_json_at("$.id", integer)
+      expect_json_at("$.name") do |value|
+        expect(value).to eq("Alex")
       end
     end
 
@@ -104,6 +117,25 @@ RSpec.describe RSpec::Rest do
       expect do
         capture :missing, "$.not_here"
       end.to raise_error(RSpec::Rest::MissingJsonPathError, /did not match path segment/)
+    end
+
+    get "/1" do
+      expect do
+        expect_json_at("$.not_here")
+      end.to raise_error(RSpec::Rest::MissingJsonPathError, /did not match path segment/)
+    end
+
+    get "/" do
+      bearer "token-123"
+      expect_status 200
+      expect(last_request[:headers]["Authorization"]).to eq("Bearer token-123")
+    end
+
+    get "/" do
+      bearer "token-123"
+      unauthenticated!
+      expect_status 200
+      expect(last_request[:headers].key?("Authorization")).to be(false)
     end
 
     resource "/{id}/posts" do

--- a/spec/rspec/rest/failure_output_spec.rb
+++ b/spec/rspec/rest/failure_output_spec.rb
@@ -56,6 +56,19 @@ RSpec.describe RSpec::Rest do
         expect(error.message).to include("-d '{\"email\":\"dump@example.com\",\"name\":\"Dump\"}'")
       }
     end
+
+    get "/" do
+      expect do
+        expect_json_at("$[0].id", 999)
+      end.to raise_error(RSpec::Expectations::ExpectationNotMetError) { |error|
+        expect(error.message).to include("Request:")
+        expect(error.message).to include("GET /v1/users")
+        expect(error.message).to include("Response:")
+        expect(error.message).to include("Status: 200")
+        expect(error.message).to include("Reproduce with:")
+        expect(error.message).to include("curl -X GET")
+      }
+    end
   end
 end
 # rubocop:enable RSpec/EmptyExampleGroup


### PR DESCRIPTION
# Pull Request

## Summary
This PR introduces the first `0.2` milestone features to reduce request-spec boilerplate and improve nested JSON assertions:

- Added auth helpers to the DSL:
  - `bearer(token)` to set `Authorization: Bearer ...`
  - `unauthenticated!` to explicitly remove `Authorization` for a request
- Added `expect_json_at(selector, expected = nil, &block)` for path-based JSON assertions (same matcher/equality/block modes as `expect_json`)
- Updated header merge behavior so `nil` request headers override/remove inherited defaults (required for `unauthenticated!`)
- Added/updated specs covering new behavior and failure output integration
- Updated README with new helper docs and refreshed example
- Added `docs/plan_0_2.md` with v0.2 feature roadmap

## Related Issue
Closes #<!-- fill if applicable -->

## User Story
As a Ruby API engineer writing request specs, I want built-in auth and JSON-path assertion helpers, so that I can write shorter, clearer specs with less repetitive setup and assertions.

## Acceptance Criteria
- [x] Add `bearer(token)` helper for auth setup
- [x] Add `unauthenticated!` helper to remove auth header for a request
- [x] Add `expect_json_at` for selector-based JSON assertions
- [x] Preserve enriched failure output (request/response dump + curl) with new expectations
- [x] Update README with new API examples/documentation

## Implementation Notes
- `expect_json_at` reuses existing `JsonSelector` behavior and error types, avoiding duplicate selector logic.
- Header merge now treats `nil` as an explicit removal signal and performs case-insensitive header key matching.
- Changes are additive and backward-compatible with existing DSL usage.
- No global RSpec monkeypatching introduced.

## Testing
- [x] `bundle exec rspec`
- [x] Added/updated specs for changed behavior
- [ ] Manual verification steps (if applicable)

### Test Evidence
`bundle exec rspec`  
`47 examples, 0 failures`

## Checklist
- [x] Backward compatibility considered
- [x] Errors/failure messages are actionable
- [x] README/docs updated (if behavior changed)
- [ ] CHANGELOG updated (if release-impacting)

## GitHub Copilot Review Instructions
When reviewing this PR, focus on the following:

1. Adhere to SOLID principles:
   - Single responsibility for classes/modules.
   - Open/closed design for extensibility.
   - Liskov substitution and interface consistency.
   - Interface segregation (small, focused APIs).
   - Dependency inversion where practical.
2. Follow Ruby gem best practices:
   - Clear public API boundaries and stable namespace (`RSpec::Rest`).
   - Minimal dependencies and explicit version constraints.
   - Meaningful error types/messages and defensive input handling.
   - Avoid global side effects/monkeypatching.
3. Follow RSpec-integrated gem best practices:
   - Deterministic specs (no order leakage, no shared mutable state).
   - Per-example isolation for config/session/captures.
   - Matchers and failures should produce high-signal diagnostics.
   - Keep DSL behavior explicit, predictable, and well-covered by specs.
4. Project-specific expectations:
   - Preserve Rack::Test in-process execution for speed.
   - Keep JSON handling robust (invalid JSON, missing keys/selectors).
   - Failure output must include enough request/response context to debug quickly.
   - Prefer readable, maintainable DSL implementation over clever metaprogramming.

If you find issues, provide concrete suggestions and point to exact files/lines.
