### PR TITLE
Add contract_with matcher helper for contract value overrides

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ Semantic Versioning.
   - Symbol keys (for example `:message`)
   - plain String keys (for example `"message"`)
   Full JSONPath selectors (for example `"$.items[0].id"`) remain supported.
+- `contract_with(:name, overrides)` for contract matcher composition with specific
+  value assertions while preserving the base contract shape/type expectations.
 
 ## [0.4.0] - 2026-03-11
 

--- a/README.md
+++ b/README.md
@@ -361,6 +361,7 @@ Available expectation helpers:
 - `expect_header(key, value_or_regex)`
 - `expect_json(expected = nil, &block)`
 - `contract(name)` (lookup helper for reusable JSON contracts)
+- `contract_with(name, overrides)` (contract lookup with value overrides)
 - `expect_json_contract(name)` (deprecated; use `contract(name)`)
 - `expect_json_at(selector, expected = nil, &block)`
 - `expect_json_first(expected = nil, &block)`
@@ -442,8 +443,12 @@ end
 get path: "/" do
   expect_status 200
   expect_json array_of(contract(:post_summary))
+  expect_json array_of(contract_with(:post_summary, id: 1, title: "My Title", author: { id: 1 }))
 end
 ```
+
+Use `contract_with` when you want the base contract shape/types plus specific values
+for selected keys. Override keys must exist in the contract definition.
 
 JSON type helpers:
 

--- a/lib/rspec/rest/contract_expectations.rb
+++ b/lib/rspec/rest/contract_expectations.rb
@@ -40,20 +40,28 @@ module RSpec
           return unknown_contract_matcher(message)
         end
 
-        base_contract_value = instance_exec(&definition)
-        key_tree = overrides_builder.key_tree_for(base_contract_value)
-        if key_tree.nil? && resolved_overrides.any?
-          return unknown_contract_matcher(
-            "Contract #{contract_name.inspect} does not declare hash keys, so overrides cannot be applied."
-          )
-        end
+        definition_for_matcher = definition
 
-        validation_error = overrides_builder.validate_keys(key_tree || {}, resolved_overrides)
-        return unknown_contract_matcher(validation_error) unless validation_error.nil?
+        if resolved_overrides.any?
+          base_contract_value = instance_exec(&definition)
+          key_tree = overrides_builder.key_tree_for(base_contract_value)
+          if key_tree.nil?
+            return unknown_contract_matcher(
+              "Contract #{contract_name.inspect} does not declare hash keys, so overrides cannot be applied."
+            )
+          end
+
+          validation_error = overrides_builder.validate_keys(key_tree || {}, resolved_overrides)
+          return unknown_contract_matcher(validation_error) unless validation_error.nil?
+
+          # Reuse the already-evaluated contract value inside the matcher so the
+          # contract definition is executed at most once per `contract_with` call.
+          definition_for_matcher = proc { base_contract_value }
+        end
 
         ContractWithMatcher.new(
           name: contract_name,
-          contract_matcher: ContractMatcher.new(name: contract_name, definition: definition, context: self),
+          contract_matcher: ContractMatcher.new(name: contract_name, definition: definition_for_matcher, context: self),
           overrides_matcher: overrides_builder.build_matcher(resolved_overrides)
         )
       end

--- a/lib/rspec/rest/contract_expectations.rb
+++ b/lib/rspec/rest/contract_expectations.rb
@@ -51,7 +51,7 @@ module RSpec
             )
           end
 
-          validation_error = overrides_builder.validate_keys(key_tree || {}, resolved_overrides)
+          validation_error = overrides_builder.validate_keys(key_tree, resolved_overrides)
           return unknown_contract_matcher(validation_error) unless validation_error.nil?
 
           # Reuse the already-evaluated contract value inside the matcher so the

--- a/lib/rspec/rest/contract_expectations.rb
+++ b/lib/rspec/rest/contract_expectations.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 require_relative "contract_matcher"
+require_relative "contract_overrides_builder"
+require_relative "contract_with_matcher"
 
 module RSpec
   module Rest
@@ -23,6 +25,37 @@ module RSpec
         )
 
         contract_matcher_for(name, lookup_name: :expect_json_contract)
+      end
+
+      def contract_with(name, overrides = nil, **keyword_overrides)
+        overrides_builder = ContractOverridesBuilder.new(context: self)
+        resolved_overrides = overrides_builder.normalize!(overrides, keyword_overrides)
+        contract_name = normalize_contract_name(name)
+        return unknown_contract_matcher(name_error_message(name, lookup_name: :contract_with)) if contract_name.nil?
+
+        definition = self.class.rest_contract_definition(contract_name)
+        if definition.nil?
+          available = self.class.send(:rest_contracts).keys.map(&:inspect).sort
+          message = "Unknown contract #{contract_name.inspect}. Available contracts: [#{available.join(', ')}]"
+          return unknown_contract_matcher(message)
+        end
+
+        base_contract_value = instance_exec(&definition)
+        key_tree = overrides_builder.key_tree_for(base_contract_value)
+        if key_tree.nil? && resolved_overrides.any?
+          return unknown_contract_matcher(
+            "Contract #{contract_name.inspect} does not declare hash keys, so overrides cannot be applied."
+          )
+        end
+
+        validation_error = overrides_builder.validate_keys(key_tree || {}, resolved_overrides)
+        return unknown_contract_matcher(validation_error) unless validation_error.nil?
+
+        ContractWithMatcher.new(
+          name: contract_name,
+          contract_matcher: ContractMatcher.new(name: contract_name, definition: definition, context: self),
+          overrides_matcher: overrides_builder.build_matcher(resolved_overrides)
+        )
       end
 
       private
@@ -50,7 +83,14 @@ module RSpec
       end
 
       def name_error_message(name, lookup_name:)
-        lookup_hint = lookup_name == :expect_json_contract ? "expect_json_contract" : "contract(:name)"
+        lookup_hint = case lookup_name
+                      when :expect_json_contract
+                        "expect_json_contract"
+                      when :contract_with
+                        "contract_with(:name, ...)"
+                      else
+                        "contract(:name)"
+                      end
         "Invalid contract name #{name.inspect} (#{name.class}). " \
           "#{lookup_hint} requires a contract name that responds to #to_sym."
       end

--- a/lib/rspec/rest/contract_overrides_builder.rb
+++ b/lib/rspec/rest/contract_overrides_builder.rb
@@ -1,0 +1,81 @@
+# frozen_string_literal: true
+
+module RSpec
+  module Rest
+    class ContractOverridesBuilder
+      def initialize(context:)
+        @context = context
+      end
+
+      def normalize!(overrides, keyword_overrides)
+        unless keyword_overrides.empty?
+          raise ArgumentError, "contract_with received both positional Hash and keyword overrides" unless overrides.nil?
+
+          return keyword_overrides
+        end
+
+        return {} if overrides.nil?
+        return overrides if overrides.is_a?(Hash)
+
+        raise ArgumentError,
+              "contract_with requires overrides to be a Hash or keyword arguments, got #{overrides.class}"
+      end
+
+      def key_tree_for(contract_value)
+        hash = extract_contract_hash(contract_value)
+        return nil if hash.nil?
+
+        hash.each_with_object({}) do |(key, nested), memo|
+          memo[key.to_s] = key_tree_for(nested)
+        end
+      end
+
+      def validate_keys(key_tree, overrides, path = [])
+        overrides.each do |key, value|
+          key_name = key.to_s
+          unless key_tree.key?(key_name)
+            available_keys = key_tree.keys.sort
+            location = path.empty? ? "contract root" : "$.#{path.join('.')}"
+            return "Unknown override key #{key_name.inspect} at #{location}. " \
+                   "Available keys: [#{available_keys.map(&:inspect).join(', ')}]"
+          end
+
+          next unless value.is_a?(Hash)
+
+          nested_tree = key_tree[key_name]
+          if nested_tree.nil?
+            location = (path + [key_name]).join(".")
+            return "Override key #{key_name.inspect} at $.#{location} does not support nested overrides."
+          end
+
+          nested_error = validate_keys(nested_tree, value, path + [key_name])
+          return nested_error unless nested_error.nil?
+        end
+
+        nil
+      end
+
+      def build_matcher(overrides)
+        @context.hash_including(
+          overrides.each_with_object({}) do |(key, value), memo|
+            memo[key.to_s] = value.is_a?(Hash) ? build_matcher(value) : value
+          end
+        )
+      end
+
+      private
+
+      def extract_contract_hash(value)
+        return value if value.is_a?(Hash)
+
+        matcher_name = value.instance_variable_get(:@matcher_name) if value.instance_variable_defined?(:@matcher_name)
+        return nil unless matcher_name == :a_hash_including
+
+        expecteds = value.instance_variable_get(:@expecteds) if value.instance_variable_defined?(:@expecteds)
+        return nil unless expecteds.is_a?(Array) && expecteds.first.is_a?(Hash)
+
+        expecteds.first
+      end
+    end
+  end
+end

--- a/lib/rspec/rest/contract_overrides_builder.rb
+++ b/lib/rspec/rest/contract_overrides_builder.rb
@@ -68,10 +68,12 @@ module RSpec
       def extract_contract_hash(value)
         return value if value.is_a?(Hash)
 
-        matcher_name = value.instance_variable_get(:@matcher_name) if value.instance_variable_defined?(:@matcher_name)
+        return nil unless value.respond_to?(:matcher_name) && value.respond_to?(:expecteds)
+
+        matcher_name = value.matcher_name
         return nil unless matcher_name == :a_hash_including
 
-        expecteds = value.instance_variable_get(:@expecteds) if value.instance_variable_defined?(:@expecteds)
+        expecteds = value.expecteds
         return nil unless expecteds.is_a?(Array) && expecteds.first.is_a?(Hash)
 
         expecteds.first

--- a/lib/rspec/rest/contract_with_matcher.rb
+++ b/lib/rspec/rest/contract_with_matcher.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+module RSpec
+  module Rest
+    class ContractWithMatcher
+      def initialize(name:, contract_matcher:, overrides_matcher:)
+        @name = name
+        @contract_matcher = contract_matcher
+        @overrides_matcher = overrides_matcher
+      end
+
+      def matches?(actual)
+        @contract_matched = @contract_matcher.matches?(actual)
+        return false unless @contract_matched
+
+        @overrides_matcher.matches?(actual)
+      end
+
+      def failure_message
+        return @contract_matcher.failure_message unless @contract_matched
+
+        "Contract #{@name.inspect} override assertion failed: #{@overrides_matcher.failure_message}"
+      end
+
+      def failure_message_when_negated
+        "Expected value not to match contract #{@name.inspect} with overrides"
+      end
+
+      def description
+        "match contract #{@name.inspect} with overrides"
+      end
+    end
+  end
+end

--- a/spec/rspec/rest/dsl_spec.rb
+++ b/spec/rspec/rest/dsl_spec.rb
@@ -102,6 +102,14 @@ RSpec.describe RSpec::Rest do
     { "enabled" => true }
   end
 
+  contract :post_summary do
+    hash_including(
+      "id" => integer,
+      "title" => string,
+      "author" => hash_including("id" => integer)
+    )
+  end
+
   it "marks expect_json_contract as deprecated" do
     allow(RSpec::Rest::Deprecation).to receive(:warn)
 
@@ -127,6 +135,58 @@ RSpec.describe RSpec::Rest do
     expect do
       contract(:inline) { hash_including("id" => integer) }
     end.to raise_error(ArgumentError, /does not accept a block/)
+  end
+
+  it "supports scalar value overrides with contract_with" do
+    payload = {
+      "id" => 1,
+      "title" => "My Title",
+      "author" => { "id" => 1, "name" => "Carl" },
+      "metadata" => { "ignored" => true }
+    }
+
+    expect(payload).to contract_with(:post_summary, id: 1, title: "My Title")
+  end
+
+  it "supports nested overrides with contract_with" do
+    payload = {
+      "id" => 1,
+      "title" => "My Title",
+      "author" => { "id" => 7, "name" => "Carl" }
+    }
+
+    expect(payload).to contract_with(:post_summary, author: { id: 7 })
+  end
+
+  it "supports matcher-valued overrides with contract_with" do
+    payload = {
+      "id" => 1,
+      "title" => "My Title",
+      "author" => { "id" => 9, "name" => "Carl" }
+    }
+
+    expect(payload).to contract_with(:post_summary, title: a_string_matching(/\AMy/))
+  end
+
+  it "supports array composition with contract_with" do
+    payload = [
+      { "id" => 1, "title" => "My Title", "author" => { "id" => 1 } },
+      { "id" => 2, "title" => "My Title", "author" => { "id" => 2 } }
+    ]
+
+    expect(payload).to array_of(contract_with(:post_summary, title: "My Title"))
+  end
+
+  it "raises a clear failure for unknown override keys" do
+    payload = {
+      "id" => 1,
+      "title" => "My Title",
+      "author" => { "id" => 1 }
+    }
+
+    expect do
+      expect(payload).to contract_with(:post_summary, missing: true)
+    end.to raise_error(RSpec::Expectations::ExpectationNotMetError, /Unknown override key "missing"/)
   end
 
   resource "/users" do

--- a/spec/rspec/rest/dsl_spec.rb
+++ b/spec/rspec/rest/dsl_spec.rb
@@ -189,6 +189,45 @@ RSpec.describe RSpec::Rest do
     end.to raise_error(RSpec::Expectations::ExpectationNotMetError, /Unknown override key "missing"/)
   end
 
+  it "raises when both positional and keyword overrides are provided" do
+    payload = {
+      "id" => 1,
+      "title" => "My Title",
+      "author" => { "id" => 1 }
+    }
+
+    expect do
+      expect(payload).to contract_with(:post_summary, { title: "One" }, title: "Two")
+    end.to raise_error(ArgumentError, /both positional Hash and keyword overrides/)
+  end
+
+  it "raises when overrides is not a Hash" do
+    payload = {
+      "id" => 1,
+      "title" => "My Title",
+      "author" => { "id" => 1 }
+    }
+
+    expect do
+      expect(payload).to contract_with(:post_summary, 123)
+    end.to raise_error(ArgumentError, /requires overrides to be a Hash/)
+  end
+
+  it "raises a clear failure for nested overrides under a scalar key" do
+    payload = {
+      "id" => 1,
+      "title" => "My Title",
+      "author" => { "id" => 1 }
+    }
+
+    expect do
+      expect(payload).to contract_with(:post_summary, title: { new: "Title" })
+    end.to raise_error(
+      RSpec::Expectations::ExpectationNotMetError,
+      /does not support nested overrides/
+    )
+  end
+
   resource "/users" do
     with_headers "X-Resource" => "users"
     with_query include_details: "true"


### PR DESCRIPTION
# Pull Request

## Summary
Add `contract_with` for composing existing contract shape/type checks with specific value overrides.

This introduces:
- `contract_with(:name, overrides)` matcher-builder in contract expectations
- deep key validation so override keys must exist in the contract definition
- nested and matcher-valued override support
- array composition support (`array_of(contract_with(...))`)

## Related Issue
Closes #53

## User Story
As a gem user writing request specs, I want to reuse contract shape/type assertions while pinning selected values, so that specs stay readable without duplicating large expected hashes.

## Acceptance Criteria
- [x] New helper `contract_with(name, overrides)` available in contract expectation DSL.
- [x] Specs cover scalar override, nested override, matcher override, array composition, and unknown-key failure messaging.
- [x] README updated with usage guidance.

## Implementation Notes
- Added `ContractWithMatcher` to combine base contract matching with override matching.
- Added `ContractOverridesBuilder` to centralize:
  - override input normalization
  - contract key tree extraction
  - override key validation
  - recursive override matcher construction
- Unknown override keys produce actionable expectation failures via the existing unknown-contract matcher mechanism.
- Implementation is additive; existing `contract(:name)` and deprecated `expect_json_contract` behavior remains unchanged.

## Testing
- [x] `bundle exec rspec`
- [x] Added/updated specs for changed behavior
- [x] Manual verification steps (if applicable)

### Test Evidence
- `bundle exec rspec spec/rspec/rest/dsl_spec.rb` -> `52 examples, 0 failures`
- `bundle exec rspec` -> `98 examples, 0 failures`
- `bundle exec rubocop` -> `42 files inspected, no offenses detected`

## Checklist
- [x] Backward compatibility considered
- [x] Errors/failure messages are actionable
- [x] README/docs updated (if behavior changed)
- [x] CHANGELOG updated (if release-impacting)

## GitHub Copilot Review Instructions
When reviewing this PR, focus on the following:

1. Adhere to SOLID principles:
   - Single responsibility for classes/modules.
   - Open/closed design for extensibility.
   - Liskov substitution and interface consistency.
   - Interface segregation (small, focused APIs).
   - Dependency inversion where practical.
2. Follow Ruby gem best practices:
   - Clear public API boundaries and stable namespace (`RSpec::Rest`).
   - Minimal dependencies and explicit version constraints.
   - Meaningful error types/messages and defensive input handling.
   - Avoid global side effects/monkeypatching.
3. Follow RSpec-integrated gem best practices:
   - Deterministic specs (no order leakage, no shared mutable state).
   - Per-example isolation for config/session/captures.
   - Matchers and failures should produce high-signal diagnostics.
   - Keep DSL behavior explicit, predictable, and well-covered by specs.
4. Project-specific expectations:
   - Preserve Rack::Test in-process execution for speed.
   - Keep JSON handling robust (invalid JSON, missing keys/selectors).
   - Failure output must include enough request/response context to debug quickly.
   - Prefer readable, maintainable DSL implementation over clever metaprogramming.

If you find issues, provide concrete suggestions and point to exact files/lines.
