### PR TITLE
Add raw response body expectation helpers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ Semantic Versioning.
   Full JSONPath selectors (for example `"$.items[0].id"`) remain supported.
 - `contract_with(:name, overrides)` for contract matcher composition with specific
   value assertions while preserving the base contract shape/type expectations.
+- Raw body expectation helpers for non-JSON/text responses:
+  - `expect_body_includes(fragment)`
+  - `expect_body_matches(pattern)`
 
 ## [0.4.0] - 2026-03-11
 

--- a/README.md
+++ b/README.md
@@ -364,6 +364,8 @@ Available expectation helpers:
 - `contract_with(name, overrides)` (contract lookup with value overrides)
 - `expect_json_contract(name)` (deprecated; use `contract(name)`)
 - `expect_json_at(selector, expected = nil, &block)`
+- `expect_body_includes(fragment)`
+- `expect_body_matches(pattern)` (`String` or `Regexp`)
 - `expect_json_first(expected = nil, &block)`
 - `expect_json_item(index, expected = nil, &block)`
 - `expect_json_last(expected = nil, &block)`
@@ -403,6 +405,16 @@ For common array-item checks, use Ruby-style helpers instead of selector strings
 expect_json_first hash_including("id" => integer)
 expect_json_item 2, hash_including("name" => "Third")
 expect_json_last { |item| expect(item["id"]).to integer }
+```
+
+Raw body assertions for text/non-JSON endpoints:
+
+```ruby
+get path: "/bad_json" do
+  expect_status 200
+  expect_body_includes "not json"
+  expect_body_matches(/this is not json/)
+end
 ```
 
 `expect_error` is a convenience helper for common API error payload assertions:

--- a/lib/rspec/rest/body_expectations.rb
+++ b/lib/rspec/rest/body_expectations.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+module RSpec
+  module Rest
+    module BodyExpectations
+      def expect_body_includes(fragment)
+        with_request_dump_on_failure do
+          expect(rest_response.body).to include(fragment)
+        end
+      end
+
+      def expect_body_matches(pattern)
+        with_request_dump_on_failure do
+          case pattern
+          when String, Regexp
+            expect(rest_response.body).to match(pattern)
+          else
+            raise ArgumentError, "expect_body_matches requires a String or Regexp pattern, got #{pattern.class}"
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/rspec/rest/body_expectations.rb
+++ b/lib/rspec/rest/body_expectations.rb
@@ -5,7 +5,12 @@ module RSpec
     module BodyExpectations
       def expect_body_includes(fragment)
         with_request_dump_on_failure do
-          expect(rest_response.body).to include(fragment)
+          case fragment
+          when String
+            expect(rest_response.body).to include(fragment)
+          else
+            raise ArgumentError, "expect_body_includes requires a String fragment, got #{fragment.class}"
+          end
         end
       end
 

--- a/lib/rspec/rest/expectations.rb
+++ b/lib/rspec/rest/expectations.rb
@@ -2,6 +2,7 @@
 
 require_relative "formatters/request_dump"
 require_relative "formatters/request_recorder"
+require_relative "body_expectations"
 require_relative "error_expectations"
 require_relative "contract_expectations"
 require_relative "header_expectations"
@@ -14,6 +15,7 @@ module RSpec
   module Rest
     module Expectations
       include ContractExpectations
+      include BodyExpectations
       include ErrorExpectations
       include HeaderExpectations
       include JsonItemExpectations

--- a/spec/rspec/rest/dsl_spec.rb
+++ b/spec/rspec/rest/dsl_spec.rb
@@ -480,6 +480,12 @@ RSpec.describe RSpec::Rest do
         expect_body_matches(123)
       end.to raise_error(ArgumentError, /requires a String or Regexp pattern/)
     end
+
+    get "" do
+      expect do
+        expect_body_includes(123)
+      end.to raise_error(ArgumentError, /requires a String fragment/)
+    end
   end
 
   resource "/posts" do

--- a/spec/rspec/rest/dsl_spec.rb
+++ b/spec/rspec/rest/dsl_spec.rb
@@ -467,6 +467,21 @@ RSpec.describe RSpec::Rest do
     end
   end
 
+  resource "/bad_json" do
+    get "" do
+      expect_status 200
+      expect_body_includes "not json"
+      expect_body_matches(/this is not json/)
+      expect_body_matches "this is not json"
+    end
+
+    get "" do
+      expect do
+        expect_body_matches(123)
+      end.to raise_error(ArgumentError, /requires a String or Regexp pattern/)
+    end
+  end
+
   resource "/posts" do
     get "/" do
       query page: 1, per_page: 2

--- a/spec/rspec/rest/failure_output_spec.rb
+++ b/spec/rspec/rest/failure_output_spec.rb
@@ -146,6 +146,21 @@ RSpec.describe RSpec::Rest do
     end
   end
 
+  resource "/bad_json" do
+    get "" do
+      expect do
+        expect_body_includes("definitely missing")
+      end.to raise_error(RSpec::Expectations::ExpectationNotMetError) { |error|
+        expect(error.message).to include("Request:")
+        expect(error.message).to include("GET /v1/bad_json")
+        expect(error.message).to include("Response:")
+        expect(error.message).to include("Status: 200")
+        expect(error.message).to include("Reproduce with:")
+        expect(error.message).to include("curl -X GET")
+      }
+    end
+  end
+
   resource "/posts" do
     get "/" do
       query page: 1, per_page: 2

--- a/spec/rspec/rest/failure_output_spec.rb
+++ b/spec/rspec/rest/failure_output_spec.rb
@@ -159,6 +159,19 @@ RSpec.describe RSpec::Rest do
         expect(error.message).to include("curl -X GET")
       }
     end
+
+    get "" do
+      expect do
+        expect_body_matches(/pattern that does not exist in body/)
+      end.to raise_error(RSpec::Expectations::ExpectationNotMetError) { |error|
+        expect(error.message).to include("Request:")
+        expect(error.message).to include("GET /v1/bad_json")
+        expect(error.message).to include("Response:")
+        expect(error.message).to include("Status: 200")
+        expect(error.message).to include("Reproduce with:")
+        expect(error.message).to include("curl -X GET")
+      }
+    end
   end
 
   resource "/posts" do


### PR DESCRIPTION
# Pull Request

## Summary
Add raw response body assertion helpers so non-JSON/text endpoints can be tested with the same DSL style as other `rspec-rest` expectations.

Added helpers:
- `expect_body_includes(fragment)`
- `expect_body_matches(pattern)` where `pattern` is `String` or `Regexp`

## Related Issue
Closes #52

## User Story
As a developer writing API specs for text/non-JSON responses, I want first-class body assertion helpers, so that I can keep tests consistent with the `rspec-rest` expectation DSL.

## Acceptance Criteria
- [x] New helper(s) documented in README expectations section
- [x] Helper failure output includes standard request/response diagnostics
- [x] Specs cover positive and negative cases

## Implementation Notes
- Added `BodyExpectations` mixin and included it in `Expectations`.
- Both helpers are wrapped in `with_request_dump_on_failure`, so failure output includes request dump and generated `curl`, consistent with existing helpers.
- `expect_body_matches` validates pattern type and raises `ArgumentError` for non-`String`/`Regexp` values.

## Testing
- [x] `bundle exec rspec`
- [x] Added/updated specs for changed behavior
- [x] Manual verification steps (if applicable)

### Test Evidence
- `bundle exec rspec spec/rspec/rest/dsl_spec.rb spec/rspec/rest/failure_output_spec.rb` -> `71 examples, 0 failures`
- `bundle exec rspec` -> `104 examples, 0 failures`
- `bundle exec rubocop` -> `43 files inspected, no offenses detected`

## Checklist
- [x] Backward compatibility considered
- [x] Errors/failure messages are actionable
- [x] README/docs updated (if behavior changed)
- [x] CHANGELOG updated (if release-impacting)

## GitHub Copilot Review Instructions
When reviewing this PR, focus on the following:

1. Adhere to SOLID principles:
   - Single responsibility for classes/modules.
   - Open/closed design for extensibility.
   - Liskov substitution and interface consistency.
   - Interface segregation (small, focused APIs).
   - Dependency inversion where practical.
2. Follow Ruby gem best practices:
   - Clear public API boundaries and stable namespace (`RSpec::Rest`).
   - Minimal dependencies and explicit version constraints.
   - Meaningful error types/messages and defensive input handling.
   - Avoid global side effects/monkeypatching.
3. Follow RSpec-integrated gem best practices:
   - Deterministic specs (no order leakage, no shared mutable state).
   - Per-example isolation for config/session/captures.
   - Matchers and failures should produce high-signal diagnostics.
   - Keep DSL behavior explicit, predictable, and well-covered by specs.
4. Project-specific expectations:
   - Preserve Rack::Test in-process execution for speed.
   - Keep JSON handling robust (invalid JSON, missing keys/selectors).
   - Failure output must include enough request/response context to debug quickly.
   - Prefer readable, maintainable DSL implementation over clever metaprogramming.

If you find issues, provide concrete suggestions and point to exact files/lines.
